### PR TITLE
Fix compilation on v1.4.0 (alternative)

### DIFF
--- a/nimcef/nc_types.nim
+++ b/nimcef/nc_types.nim
@@ -60,7 +60,7 @@ else:
     result.args.argc = count.cint
     nim_params = newSeq[string](count)
     c_params = newSeq[cstring](count+1)
-    for i in 0.. <count:
+    for i in 0..<count:
       nim_params[i] = paramStr(i)
       c_params[i] = nim_params[i][0].addr
     c_params[count] = nil

--- a/util/nc_util.nim
+++ b/util/nc_util.nim
@@ -1029,7 +1029,8 @@ proc handlerImplImpl(nc: NimNode, methods: NimNode, constructorVisible: bool): s
 
 macro handlerImpl*(nc: typed, methods: varargs[typed]): untyped =
   let glue = handlerImplImpl(nc, methods, true)
-  result = parseStmt(glue)
+  result = methods[0]
+  result.add parseStmt(glue)
 
 macro closureHandlerImpl*(nc: typed, methods: varargs[typed]): untyped =
   let glue = handlerImplImpl(nc, methods, false)


### PR DESCRIPTION
This is quite a bit less modification, but it also enables building on v1.4.0 (at least while `csize` is still around, it is deprecated after all).